### PR TITLE
Migrate to Manifest V3 for Chrome Web Store compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "UnicornPass",
   "version": "0.2.1",
   "author": "Carlos Melero",
@@ -8,8 +7,9 @@
   "description": "Colorful password fields using SHA1 hash of your password. You will know if you typed the correct password before submitting.",
 
   "icons": {
+    "16": "icon.png",
     "48": "icon.png",
-    "96": "icon.png"
+    "128": "icon.png"
   },
 
   "content_scripts": [
@@ -18,13 +18,19 @@
       "js": ["data/unicornpass.js"]
     }
   ],
+  
   "background": {
-    "scripts": ["main.js"]
+    "service_worker": "main.js"
   },
 
   "options_ui": {
-    "page": "data/options.html"
+    "page": "data/options.html",
+    "open_in_tab": false
   },
 
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  
+  "action": {
+    "default_title": "UnicornPass"
+  }
 }


### PR DESCRIPTION
# Migrate to Manifest V3 for Chrome Web Store Compatibility

This PR updates the UnicornPass extension to be compatible with Manifest V3, which is now required for Chrome Web Store submissions.

##  Overview

Chrome is deprecating Manifest V2 and will stop accepting new extensions using the old format. This migration ensures UnicornPass remains compatible with current Chrome extension standards and can be published/updated on the Chrome Web Store.

## Changes Made

### Core Updates
- **Manifest Version**: Updated from V2 to V3
- **Background Scripts**: Replaced with service worker architecture
- **Icons**: Added required icon sizes (16px, 48px, 128px) for Chrome Web Store
